### PR TITLE
Fix class name for numeric buttons

### DIFF
--- a/src/Componentes/boton.js
+++ b/src/Componentes/boton.js
@@ -11,7 +11,7 @@ function Boton  (props) {
 
 
     return (
-        <div  className={`boton ${esOperador(props.children) ? 'operador' : null}` }
+        <div  className={`boton ${esOperador(props.children) ? 'operador' : ''}` }
         onClick={ () => props.manejarClick(props.children)}>    
         {props.children}
         </div>


### PR DESCRIPTION
## Summary
- fix incorrect `null` class name on numeric buttons

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848a0f8651c832794cf5c251ae30514