### PR TITLE
Add basic Clear button test

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import App from './App';
+
+test('Clear button resets the display', () => {
+  const { container } = render(<App />);
+  const display = container.querySelector('.input');
+
+  userEvent.click(screen.getByText('1'));
+  expect(display.textContent).toBe('1');
+
+  userEvent.click(screen.getByText(/Clear/i));
+  expect(display.textContent).toBe('');
+});


### PR DESCRIPTION
## Summary
- add a React Testing Library test to ensure the Clear button resets the display

## Testing
- `npm test --silent -- -w 1` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848a2822c4883278ed888424edc7e39