### PR TITLE
Fix App class name in CSS

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,4 +1,4 @@
-.app {
+.App {
 
   width: 100%;
   height: 100%;


### PR DESCRIPTION
## Summary
- rename `.app` selector to `.App` so styles load

## Testing
- `npm start --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848a276de0c832793d556ded023771e