### PR TITLE
Add pretest hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "pretest": "npm install",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
## Summary
- run `npm install` automatically before test commands

## Testing
- `npm test --silent` *(fails: npm install blocked by network)*

------
https://chatgpt.com/codex/tasks/task_e_687fcc74c7548327a573527f85526770